### PR TITLE
Update DecodedEntityClass.cs

### DIFF
--- a/GenericServices/Internal/Decoders/DecodedEntityClass.cs
+++ b/GenericServices/Internal/Decoders/DecodedEntityClass.cs
@@ -51,7 +51,7 @@ namespace GenericServices.Internal.Decoders
         public DecodedEntityClass(Type entityType, DbContext context)
         {
             EntityType = entityType ?? throw new ArgumentNullException(nameof(entityType));
-            var efType = context.Model.FindEntityType(entityType.FullName);
+            var efType = context.Model.FindEntityType(entityType);
             if (efType == null)
             {
                 throw new InvalidOperationException($"The class {entityType.Name} was not found in the {context.GetType().Name} DbContext."+


### PR DESCRIPTION
When using IdentityDbContext as DBContext this line gives InvalidOperationException 'The class IdentityRoleClaim`1 was not found in the ApplicationDbContext DbContext. The class must be either be an entity class derived from the GenericServiceDto/Async class.'
This can be solved by using FIndEntityType overload with 'Type' parameter instead of 'string'.

![screenshot_8](https://user-images.githubusercontent.com/2683569/53950065-a7d7fe80-40cb-11e9-9223-b9fa72898567.png)
