### PR TITLE
saving nested dto's works by including propertynames if the name is not different from entity property name

### DIFF
--- a/GenericServices/ICrudServices.cs
+++ b/GenericServices/ICrudServices.cs
@@ -87,6 +87,11 @@ namespace GenericServices
         void UpdateAndSave<T>(T entityOrDto, string methodName = null, string[] includes = null) where T : class;
 
         /// <summary>
+        /// Combination of UpdateAndSave and DeleteWithActionAndSave.
+        /// </summary>
+        void UpdateWithActionAndSave<TDto, TEntity>(Func<DbContext, TEntity, IStatusGeneric> runBeforeUpdate, TDto entityOrDto, string methodName = null, string[] includes = null) where TDto : class where TEntity : class;
+
+        /// <summary>
         /// This allows you to update properties with public setters using a JsonPatch <cref>http://jsonpatch.com/</cref>
         /// The keys allow you to define which entity class you want updated
         /// </summary>

--- a/GenericServices/ICrudServices.cs
+++ b/GenericServices/ICrudServices.cs
@@ -84,12 +84,25 @@ namespace GenericServices
         /// <param name="entityOrDto">This should either be an instance of a entity class or a CrudServices DTO which has a <see cref="ILinkToEntity{TEntity}"/> interface</param>
         /// <param name="methodName">Optional: you can give the method name to be used for the update, or CrudValues.UseAutoMapper to make it use AutoMapper to update the entity.</param>
         /// <param name="includes"></param>
-        void UpdateAndSave<T>(T entityOrDto, string methodName = null, string[] includes = null) where T : class;
+        void UpdateAndSave<T>(T entityOrDto, string methodName, params Expression<Func<T, object>>[] includes) where T : class;
+
+        /// <summary>
+        /// This will update the entity referred to by the keys in the given class instance.
+        /// For a entity class instance it will check the state of the instance. If its detached it will call Update, otherwise it assumes its tracked and calls SaveChanges
+        /// For a CrudServices DTO it will: 
+        /// a) load the existing entity class using the primary key(s) in the DTO
+        /// b) This it will look for a public method that match the DTO's properties to do the update, or if no method is found it will try to use AutoMapper to copy the data over to the e
+        /// c) finally it will call SaveChanges
+        /// </summary>
+        /// <typeparam name="T">This type is found from the input instance</typeparam>
+        /// <param name="entityOrDto">This should either be an instance of a entity class or a CrudServices DTO which has a <see cref="ILinkToEntity{TEntity}"/> interface</param>
+        /// <param name="includes"></param>
+        void UpdateAndSave<T>(T entityOrDto, params Expression<Func<T, object>>[] includes) where T : class;
 
         /// <summary>
         /// Combination of UpdateAndSave and DeleteWithActionAndSave.
         /// </summary>
-        void UpdateWithActionAndSave<TDto, TEntity>(Func<DbContext, TEntity, IStatusGeneric> runBeforeUpdate, TDto entityOrDto, string methodName = null, string[] includes = null) where TDto : class where TEntity : class;
+        void UpdateWithActionAndSave<TDto, TEntity>(Func<DbContext, TEntity, IStatusGeneric> runBeforeUpdate, TDto entityOrDto, string methodName = null, params Expression<Func<TDto, object>>[] includes) where TDto : class where TEntity : class;
 
         /// <summary>
         /// This allows you to update properties with public setters using a JsonPatch <cref>http://jsonpatch.com/</cref>

--- a/GenericServices/ICrudServices.cs
+++ b/GenericServices/ICrudServices.cs
@@ -83,7 +83,8 @@ namespace GenericServices
         /// <typeparam name="T">This type is found from the input instance</typeparam>
         /// <param name="entityOrDto">This should either be an instance of a entity class or a CrudServices DTO which has a <see cref="ILinkToEntity{TEntity}"/> interface</param>
         /// <param name="methodName">Optional: you can give the method name to be used for the update, or CrudValues.UseAutoMapper to make it use AutoMapper to update the entity.</param>
-        void UpdateAndSave<T>(T entityOrDto, string methodName = null) where T : class;
+        /// <param name="includes"></param>
+        void UpdateAndSave<T>(T entityOrDto, string methodName = null, string[] includes = null) where T : class;
 
         /// <summary>
         /// This allows you to update properties with public setters using a JsonPatch <cref>http://jsonpatch.com/</cref>

--- a/GenericServices/ICrudServicesAsync.cs
+++ b/GenericServices/ICrudServicesAsync.cs
@@ -81,8 +81,9 @@ namespace GenericServices
         /// <typeparam name="T">This type is found from the input instance</typeparam>
         /// <param name="entityOrDto">This should either be an instance of a entity class or a CrudServices DTO which has a <see cref="ILinkToEntity{TEntity}"/> interface</param>
         /// <param name="methodName">Optional: you can give the method name to be used for the update, or CrudValues.UseAutoMapper to make it use AutoMapper to update the entity.</param>
+        /// <param name="includes"></param>
         /// <returns>Task, async</returns>
-        Task UpdateAndSaveAsync<T>(T entityOrDto, string methodName = null) where T : class;
+        Task UpdateAndSaveAsync<T>(T entityOrDto, string methodName = null, string[] includes = null) where T : class;
 
         /// <summary>
         /// This allows you to update properties with public setters using a JsonPatch <cref>http://jsonpatch.com/</cref>

--- a/GenericServices/ICrudServicesAsync.cs
+++ b/GenericServices/ICrudServicesAsync.cs
@@ -83,7 +83,7 @@ namespace GenericServices
         /// <param name="methodName">Optional: you can give the method name to be used for the update, or CrudValues.UseAutoMapper to make it use AutoMapper to update the entity.</param>
         /// <param name="includes"></param>
         /// <returns>Task, async</returns>
-        Task UpdateAndSaveAsync<T>(T entityOrDto, string methodName = null, string[] includes = null) where T : class;
+        Task UpdateAndSaveAsync<T>(T entityOrDto, string methodName = null, params Expression<Func<T, object>>[] includes) where T : class;
 
         /// <summary>
         /// This allows you to update properties with public setters using a JsonPatch <cref>http://jsonpatch.com/</cref>

--- a/GenericServices/Internal/MappingCode/CreateMapper.cs
+++ b/GenericServices/Internal/MappingCode/CreateMapper.cs
@@ -71,13 +71,13 @@ namespace GenericServices.Internal.MappingCode
                 _wrappedMapper.MapperSaveConfig.CreateMapper().Map(dto, entity);
             }
 
-            public TEntity ReturnExistingEntity(Dictionary<string, object> keys, string[] includes)
+            public TEntity ReturnExistingEntity<TP>(Dictionary<string, object> keys, Expression<Func<TEntity, TP>>[] includes) where TP: class
             {
                 var result = (IQueryable<TEntity>)_context.Set<TEntity>();
 
                 if (includes != null)
                 {
-                    foreach (var include in includes)
+                    foreach (Expression<Func<TEntity, TP>> include in includes)
                     {
                         result = result.Include(include);
                     }

--- a/GenericServices/Internal/MappingCode/CreateMapper.cs
+++ b/GenericServices/Internal/MappingCode/CreateMapper.cs
@@ -71,15 +71,17 @@ namespace GenericServices.Internal.MappingCode
                 _wrappedMapper.MapperSaveConfig.CreateMapper().Map(dto, entity);
             }
 
-            public TEntity ReturnExistingEntity<TP>(Dictionary<string, object> keys, Expression<Func<TEntity, TP>>[] includes) where TP: class
+            public TEntity ReturnExistingEntity(Dictionary<string, object> keys, Expression<Func<TDto, object>>[] includes)
             {
                 var result = (IQueryable<TEntity>)_context.Set<TEntity>();
 
+
                 if (includes != null)
                 {
-                    foreach (Expression<Func<TEntity, TP>> include in includes)
+                    foreach(var include in includes)
                     {
-                        result = result.Include(include);
+                        MemberExpression me = (MemberExpression)include.Body;                       
+                        result = result.Include(me.Member.Name);
                     }
                 }
 

--- a/GenericServices/Internal/MappingCode/EntityUpdateHandler.cs
+++ b/GenericServices/Internal/MappingCode/EntityUpdateHandler.cs
@@ -9,7 +9,6 @@ using GenericServices.PublicButHidden;
 using GenericServices.Internal.LinqBuilders;
 using Microsoft.EntityFrameworkCore;
 using System.Linq.Expressions;
-using GenericServices.Configuration;
 
 namespace GenericServices.Internal.MappingCode
 {

--- a/GenericServices/Internal/MappingCode/EntityUpdateHandler.cs
+++ b/GenericServices/Internal/MappingCode/EntityUpdateHandler.cs
@@ -9,6 +9,7 @@ using GenericServices.PublicButHidden;
 using GenericServices.Internal.LinqBuilders;
 using Microsoft.EntityFrameworkCore;
 using System.Linq.Expressions;
+using GenericServices.Configuration;
 
 namespace GenericServices.Internal.MappingCode
 {
@@ -33,6 +34,7 @@ namespace GenericServices.Internal.MappingCode
             //first we need to load it 
             var keys = _context.GetKeysFromDtoInCorrectOrder(dto, _dtoInfo);
             var mapper = new CreateMapper(_context, _configAndMapper, typeof(TDto), _entityInfo);
+
             var entity = mapper.Accessor.ReturnExistingEntity(keys, includes);
             if (entity == null)
                 return new StatusGenericHandler()

--- a/GenericServices/Internal/MappingCode/EntityUpdateHandler.cs
+++ b/GenericServices/Internal/MappingCode/EntityUpdateHandler.cs
@@ -8,6 +8,7 @@ using GenericServices.Internal.Decoders;
 using GenericServices.PublicButHidden;
 using GenericServices.Internal.LinqBuilders;
 using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
 
 namespace GenericServices.Internal.MappingCode
 {
@@ -27,7 +28,7 @@ namespace GenericServices.Internal.MappingCode
             _context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
-        public IStatusGeneric ReadEntityAndUpdateViaDto(TDto dto, string methodName, string[] includes)
+        public IStatusGeneric ReadEntityAndUpdateViaDto(TDto dto, string methodName, params Expression<Func<TDto, object>>[] includes)
         {
             //first we need to load it 
             var keys = _context.GetKeysFromDtoInCorrectOrder(dto, _dtoInfo);

--- a/GenericServices/Internal/MappingCode/EntityUpdateHandler.cs
+++ b/GenericServices/Internal/MappingCode/EntityUpdateHandler.cs
@@ -27,12 +27,12 @@ namespace GenericServices.Internal.MappingCode
             _context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
-        public IStatusGeneric ReadEntityAndUpdateViaDto(TDto dto, string methodName)
+        public IStatusGeneric ReadEntityAndUpdateViaDto(TDto dto, string methodName, string[] includes)
         {
             //first we need to load it 
             var keys = _context.GetKeysFromDtoInCorrectOrder(dto, _dtoInfo);
             var mapper = new CreateMapper(_context, _configAndMapper, typeof(TDto), _entityInfo);
-            var entity = mapper.Accessor.ReturnExistingEntity(keys);
+            var entity = mapper.Accessor.ReturnExistingEntity(keys, includes);
             if (entity == null)
                 return new StatusGenericHandler()
                     .AddError(

--- a/GenericServices/Internal/MappingCode/KeyHandlers.cs
+++ b/GenericServices/Internal/MappingCode/KeyHandlers.cs
@@ -40,10 +40,10 @@ namespace GenericServices.Internal.MappingCode
         /// <param name="dto"></param>
         /// <param name="dtoInfo"></param>
         /// <returns></returns>
-        public static object[] GetKeysFromDtoInCorrectOrder<TDto>(this DbContext context, TDto dto, DecodedDto dtoInfo)
+        public static Dictionary<string, object> GetKeysFromDtoInCorrectOrder<TDto>(this DbContext context, TDto dto, DecodedDto dtoInfo)
             where TDto : class
         {
-            var keys = new List<object>();
+            var keys = new Dictionary<string, object>();
 
             foreach (var entityKey in context.Model.FindEntityType(dtoInfo.LinkedEntityInfo.EntityType).FindPrimaryKey().Properties)
             {
@@ -51,10 +51,10 @@ namespace GenericServices.Internal.MappingCode
                 if (dtoKeyProperty == null)
                     throw new InvalidOperationException($"The DTO/VM class {typeof(TDto).Name} does not contain the primary key {entityKey.Name}."+
                                                         " You have to include every part of a primary key in the DTO for this service to work.");
-                keys.Add(dtoKeyProperty.PropertyInfo.GetValue(dto));
+                keys.Add(dtoKeyProperty.PropertyInfo.Name, dtoKeyProperty.PropertyInfo.GetValue(dto));
             }
 
-            return keys.ToArray();
+            return keys;
         }
     }
 }

--- a/GenericServices/PublicButHidden/CrudServices.cs
+++ b/GenericServices/PublicButHidden/CrudServices.cs
@@ -167,7 +167,13 @@ namespace GenericServices.PublicButHidden
         }
 
         /// <inheritdoc />
-        public void UpdateAndSave<T>(T entityOrDto, string methodName = null, string[] includes = null) where T : class
+        public void UpdateAndSave<T>(T entityOrDto, params Expression<Func<T, object>>[] includes) where T : class
+        {
+            UpdateAndSave(entityOrDto, methodName: null, includes: includes);
+        }
+
+        /// <inheritdoc />
+        public void UpdateAndSave<T>(T entityOrDto, string methodName, params Expression<Func<T, object>>[] includes) where T : class
         {
             var entityInfo = _context.GetEntityInfoThrowExceptionIfNotThere(typeof(T));
             entityInfo.CheckCanDoOperation(CrudTypes.Update);
@@ -193,7 +199,7 @@ namespace GenericServices.PublicButHidden
         }
 
         /// <inheritdoc />
-        public void UpdateWithActionAndSave<TDto, TEntity>(Func<DbContext, TEntity, IStatusGeneric> runBeforeUpdate, TDto entityOrDto, string methodName = null, string[] includes = null) where TDto : class where TEntity : class
+        public void UpdateWithActionAndSave<TDto, TEntity>(Func<DbContext, TEntity, IStatusGeneric> runBeforeUpdate, TDto entityOrDto, string methodName = null, params Expression<Func<TDto, object>>[] includes) where TDto : class where TEntity : class
         {
             var entityInfo = _context.GetEntityInfoThrowExceptionIfNotThere(typeof(TDto));
 

--- a/GenericServices/PublicButHidden/CrudServices.cs
+++ b/GenericServices/PublicButHidden/CrudServices.cs
@@ -167,7 +167,7 @@ namespace GenericServices.PublicButHidden
         }
 
         /// <inheritdoc />
-        public void UpdateAndSave<T>(T entityOrDto, string methodName = null) where T : class
+        public void UpdateAndSave<T>(T entityOrDto, string methodName = null, string[] includes = null) where T : class
         {
             var entityInfo = _context.GetEntityInfoThrowExceptionIfNotThere(typeof(T));
             entityInfo.CheckCanDoOperation(CrudTypes.Update);
@@ -185,7 +185,7 @@ namespace GenericServices.PublicButHidden
             {
                 var dtoInfo = typeof(T).GetDtoInfoThrowExceptionIfNotThere();
                 var updater = new EntityUpdateHandler<T>(dtoInfo, entityInfo, _configAndMapper, _context);
-                CombineStatuses(updater.ReadEntityAndUpdateViaDto(entityOrDto, methodName));
+                CombineStatuses(updater.ReadEntityAndUpdateViaDto(entityOrDto, methodName, includes));
                 if (IsValid)
                     CombineStatuses(_context.SaveChangesWithOptionalValidation(
                         dtoInfo.ShouldValidateOnSave(_configAndMapper.Config), _configAndMapper.Config));

--- a/GenericServices/PublicButHidden/CrudServicesAsync.cs
+++ b/GenericServices/PublicButHidden/CrudServicesAsync.cs
@@ -170,7 +170,7 @@ namespace GenericServices.PublicButHidden
         }
 
         /// <inheritdoc />
-        public async Task UpdateAndSaveAsync<T>(T entityOrDto, string methodName = null) where T : class
+        public async Task UpdateAndSaveAsync<T>(T entityOrDto, string methodName = null, string[] includes = null) where T : class
         {
             var entityInfo = _context.GetEntityInfoThrowExceptionIfNotThere(typeof(T));
             entityInfo.CheckCanDoOperation(CrudTypes.Update);
@@ -188,7 +188,7 @@ namespace GenericServices.PublicButHidden
             {
                 var dtoInfo = typeof(T).GetDtoInfoThrowExceptionIfNotThere();
                 var updater = new EntityUpdateHandler<T>(dtoInfo, entityInfo, _configAndMapper, _context);
-                CombineStatuses(updater.ReadEntityAndUpdateViaDto(entityOrDto, methodName));
+                CombineStatuses(updater.ReadEntityAndUpdateViaDto(entityOrDto, methodName, includes));
                 if (IsValid)
                     CombineStatuses(await _context.SaveChangesWithOptionalValidationAsync(
                         dtoInfo.ShouldValidateOnSave(_configAndMapper.Config), _configAndMapper.Config));

--- a/GenericServices/PublicButHidden/CrudServicesAsync.cs
+++ b/GenericServices/PublicButHidden/CrudServicesAsync.cs
@@ -170,7 +170,7 @@ namespace GenericServices.PublicButHidden
         }
 
         /// <inheritdoc />
-        public async Task UpdateAndSaveAsync<T>(T entityOrDto, string methodName = null, string[] includes = null) where T : class
+        public async Task UpdateAndSaveAsync<T>(T entityOrDto, string methodName = null, params Expression<Func<T, object>>[] includes) where T : class
         {
             var entityInfo = _context.GetEntityInfoThrowExceptionIfNotThere(typeof(T));
             entityInfo.CheckCanDoOperation(CrudTypes.Update);

--- a/Tests/UnitTests/GenericServicesInternal/TestKeyHandlers.cs
+++ b/Tests/UnitTests/GenericServicesInternal/TestKeyHandlers.cs
@@ -7,6 +7,7 @@ using Tests.EfClasses;
 using Tests.EfCode;
 using TestSupport.EfHelpers;
 using Xunit.Extensions.AssertExtensions;
+using System.Linq;
 
 namespace Tests.UnitTests.GenericServicesInternal
 {
@@ -26,9 +27,9 @@ namespace Tests.UnitTests.GenericServicesInternal
                 //ATTEMPT
                 var dto = new NormalEntityDto {Id = 123};
                 var keys = context.GetKeysFromDtoInCorrectOrder(dto, decodeDto);
-
+              
                 //VERIFY
-                ((int)keys[0]).ShouldEqual(123);
+                ((int)keys.Values.First()).ShouldEqual(123);
             }
         }
 


### PR DESCRIPTION
As in #21 and #25 updating nested dto's fails 
In the given example at [https://github.com/bleissem/TestNestedInDtosIssue13](https://github.com/bleissem/TestNestedInDtosIssue13)
the failing unit tests works with commit
https://github.com/bleissem/TestNestedInDtosIssue13/commit/b0b33929f32a1941add0b3e05ad27b93f8535d14
because of providing the navigation properties as an expression as long as the name is not different than the db entity name
