### PR TITLE
Fixes issue #30

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,6 +5,10 @@
             "label": "build",
             "command": "dotnet",
             "type": "process",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
             "args": [
                 "build",
                 "${workspaceFolder}/RazorPageApp/RazorPageApp.csproj"

--- a/GenericServices/Configuration/PropertyMatch.cs
+++ b/GenericServices/Configuration/PropertyMatch.cs
@@ -20,6 +20,8 @@ namespace GenericServices.Configuration
     /// </summary>
     public class PropertyMatch
     {
+        internal static readonly PropertyMatch Empty = new PropertyMatch(false, TypeMatchLevels.NoMatch, null);
+
         /// <summary>
         /// Use "score >= PerfectMatchValue" to check if there is a perfect match
         /// </summary>

--- a/GenericServices/Internal/Decoders/ParametersMatch.cs
+++ b/GenericServices/Internal/Decoders/ParametersMatch.cs
@@ -48,7 +48,7 @@ namespace GenericServices.Internal.Decoders
                 if (bestMatch == null || bestMatch.Score < match.Score)
                     bestMatch = match;
             }
-            return bestMatch;
+            return bestMatch ?? PropertyMatch.Empty;
         }
 
     }

--- a/Tests/Dtos/EmptyLinkedToImmutableEntityDto.cs
+++ b/Tests/Dtos/EmptyLinkedToImmutableEntityDto.cs
@@ -1,0 +1,9 @@
+using GenericServices;
+using Tests.EfClasses;
+
+namespace Tests.Dtos
+{
+    public class EmptyLinkedToImmutableEntityDto : ILinkToEntity<DddCompositeIntString>
+    {
+    }
+}

--- a/Tests/Dtos/EmptyLinkedToMutableEntityDto.cs
+++ b/Tests/Dtos/EmptyLinkedToMutableEntityDto.cs
@@ -1,0 +1,9 @@
+using GenericServices;
+using Tests.EfClasses;
+
+namespace Tests.Dtos
+{
+    public class EmptyLinkedToMutableEntityDto : ILinkToEntity<NormalEntity>
+    {
+    }
+}

--- a/Tests/Dtos/ReadonlyLinkedToImmutableEntityDto.cs
+++ b/Tests/Dtos/ReadonlyLinkedToImmutableEntityDto.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel;
+using GenericServices;
+using Tests.EfClasses;
+
+namespace Tests.Dtos
+{
+    public class ReadonlyLinkedToImmutableEntityDto : ILinkToEntity<DddCompositeIntString>
+    {
+        [ReadOnly(true)]
+        public int Id { get; set; }
+    }
+}

--- a/Tests/Dtos/ReadonlyLinkedToMutableEntityDto.cs
+++ b/Tests/Dtos/ReadonlyLinkedToMutableEntityDto.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel;
+using GenericServices;
+using Tests.EfClasses;
+
+namespace Tests.Dtos
+{
+    public class ReadonlyLinkedToMutableEntityDto : ILinkToEntity<NormalEntity>
+    {
+        [ReadOnly(true)]
+        public int Id { get; set; }
+    }
+}

--- a/Tests/UnitTests/GenericServicesPublic/TestNonWritableDto.cs
+++ b/Tests/UnitTests/GenericServicesPublic/TestNonWritableDto.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Linq;
+using GenericServices.PublicButHidden;
+using GenericServices.Setup;
+using Tests.Dtos;
+using Tests.EfCode;
+using TestSupport.EfHelpers;
+using Xunit;
+using Xunit.Extensions.AssertExtensions;
+
+namespace Tests.DataLayer
+{
+    public class TestNonWritableDto
+    {
+        [Fact]
+        public void TestEmptyLinkedToImmutableEntityDto()
+        {
+            //SETUP
+            InvalidOperationException exception;
+            var options = SqliteInMemory.CreateOptions<TestDbContext>();
+            using (var context = new TestDbContext(options))
+            {
+                context.Database.EnsureCreated();
+
+                //ATTEMPT
+                var utData = context.SetupSingleDtoAndEntities<EmptyLinkedToImmutableEntityDto>();
+                var service = new CrudServices(context, utData.ConfigAndMapper);
+                exception = Assert.Throws<InvalidOperationException>(() => service.CreateAndSave(new EmptyLinkedToImmutableEntityDto()));
+            }
+
+            //VERIFY
+            exception.Message.ShouldStartWith("Could not find a ctor/static method that matches the DTO. The ctor/static method that fit the properties in the DTO/VM are:");
+        }
+
+        [Fact]
+        public void TestEmptyLinkedToMutableEntityDto()
+        {
+            //SETUP
+            var options = SqliteInMemory.CreateOptions<TestDbContext>();
+            using (var context = new TestDbContext(options))
+            {
+                context.Database.EnsureCreated();
+
+                //ATTEMPT
+                var utData = context.SetupSingleDtoAndEntities<EmptyLinkedToMutableEntityDto>();
+                var service = new CrudServices(context, utData.ConfigAndMapper);
+                service.CreateAndSave(new EmptyLinkedToMutableEntityDto());
+            }
+
+            //VERIFY
+            using (var context = new TestDbContext(options))
+            {
+                var normalEntities = context.NormalEntities.ToList();
+                normalEntities.Count.ShouldEqual(1);
+                normalEntities[0].ShouldNotBeNull();
+                normalEntities[0].Id.ShouldEqual(1);
+                normalEntities[0].MyInt.ShouldEqual(0);
+                normalEntities[0].MyString.ShouldBeNull();
+            }
+        }
+
+
+        [Fact]
+        public void TestReadonlyLinkedToImmutableEntityDto()
+        {
+            //SETUP
+            InvalidOperationException exception;
+            var options = SqliteInMemory.CreateOptions<TestDbContext>();
+            using (var context = new TestDbContext(options))
+            {
+                context.Database.EnsureCreated();
+
+                //ATTEMPT
+                var utData = context.SetupSingleDtoAndEntities<ReadonlyLinkedToImmutableEntityDto>();
+                var service = new CrudServices(context, utData.ConfigAndMapper);
+                exception = Assert.Throws<InvalidOperationException>(() => service.CreateAndSave(new EmptyLinkedToImmutableEntityDto()));
+            }
+
+            //VERIFY
+            exception.Message.ShouldStartWith("Could not find a ctor/static method that matches the DTO. The ctor/static method that fit the properties in the DTO/VM are:");
+        }
+
+        [Fact]
+        public void TestReadonlyLinkedToMutableEntityDto()
+        {
+            //SETUP
+            var options = SqliteInMemory.CreateOptions<TestDbContext>();
+            using (var context = new TestDbContext(options))
+            {
+                context.Database.EnsureCreated();
+
+                //ATTEMPT
+                var utData = context.SetupSingleDtoAndEntities<ReadonlyLinkedToMutableEntityDto>();
+                var service = new CrudServices(context, utData.ConfigAndMapper);
+                service.CreateAndSave(new ReadonlyLinkedToMutableEntityDto());
+            }
+
+            //VERIFY
+            using (var context = new TestDbContext(options))
+            {
+                var normalEntities = context.NormalEntities.ToList();
+                normalEntities.Count.ShouldEqual(1);
+                normalEntities[0].ShouldNotBeNull();
+                normalEntities[0].Id.ShouldEqual(1);
+                normalEntities[0].MyInt.ShouldEqual(0);
+                normalEntities[0].MyString.ShouldBeNull();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi, 

Please take a look at the change and let me know what do you think about this fixing.

The issue is that when there are immutable entities, a method match will be tried and, if there is no DTO writable property, a null property match is returned as the best match. Then, the following code assumes that we always have a PropertyMatch instance, causing a null exception.

I will be happy to make any change you want to.