### PR TITLE
Upgrade .net core 3.0.0 breaking change in EntityFrameworkCore  IsQueryType removed

### DIFF
--- a/GenericServices/Internal/Decoders/DecodedEntityClass.cs
+++ b/GenericServices/Internal/Decoders/DecodedEntityClass.cs
@@ -58,7 +58,7 @@ namespace GenericServices.Internal.Decoders
                                                     " The class must be either be an entity class derived from the GenericServiceDto/Async class.");
             }
 
-            if (efType.IsQueryType)
+            if (efType.FindPrimaryKey() == null)
             {
                 //QueryType is read only, so we don't do any further setup
                 EntityStyle = EntityStyles.DbQuery;


### PR DESCRIPTION
Hi Jon,

We are trying to upgrade our project which uses EFCore.GenericServices to .NET Core 3.0-preview9.

In EntityFrameworkCore they introduced the following breaking change by removing **IsQueryType** from the **IEntityType** interface:
https://github.com/aspnet/EntityFrameworkCore/issues/14194

In **DecodedEntityClass** this property is used and thus breaking current implementation.


