### PR TITLE
Linq query not working

### DIFF
--- a/Tests/UnitTests/GenericServicesPublic/TestNestedInDtosIssue13.cs
+++ b/Tests/UnitTests/GenericServicesPublic/TestNestedInDtosIssue13.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2018 Jon P Smith, GitHub: JonPSmith, web: http://www.thereformedprogrammer.net/
 // Licensed under MIT licence. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using GenericServices.PublicButHidden;
 using GenericServices.Setup;
@@ -45,9 +46,41 @@ namespace Tests.UnitTests.GenericServicesPublic
                 contact.Name.ShouldEqual("test");
                 contact.Address.Address1.ShouldEqual("some street");
             }
-        }
+		}
 
-        
+		[Fact]
+		public void TestInDtosNestedOk2()
+		{
+			//SETUP
+			var options = SqliteInMemory.CreateOptions<TestDbContext>();
+			using (var context = new TestDbContext(options))
+			{
+				context.Database.EnsureCreated();
 
-    }
+				var utData = context.SetupSingleDtoAndEntities<InContactAddressDto>();
+				utData.AddSingleDto<InAddressDto>();
+				var service = new CrudServices(context, utData.ConfigAndMapper);
+
+				//ATTEMPT
+				var dto = new InContactAddressDto
+				{
+					Name = "test",
+					Addess = new InAddressDto
+					{
+						Address1 = "some street"
+					}
+				};
+				service.CreateAndSave(dto);
+
+				//VERIFY
+				service.IsValid.ShouldBeTrue(service.GetAllErrors());
+				var contact = context.ContactAddresses.SingleOrDefault();
+				contact.Name.ShouldEqual("test");
+
+				IList<InContactAddressDto> resp = service.ReadManyNoTracked<InContactAddressDto>().Where(x => x.Addess.Address1 == "some street").ToList();
+
+				contact.Address.Address1.ShouldEqual("some street");
+			}
+		}
+	}
 }

--- a/Tests/UnitTests/GenericServicesPublic/TestNestedInDtosIssue13.cs
+++ b/Tests/UnitTests/GenericServicesPublic/TestNestedInDtosIssue13.cs
@@ -13,39 +13,39 @@ using Xunit.Extensions.AssertExtensions;
 
 namespace Tests.UnitTests.GenericServicesPublic
 {
-    public class TestNestedInDtosIssue13
-    {
+	public class TestNestedInDtosIssue13
+	{
 
-        [Fact]
-        public void TestInDtosNestedOk()
-        {
-            //SETUP
-            var options = SqliteInMemory.CreateOptions<TestDbContext>();
-            using (var context = new TestDbContext(options))
-            {
-                context.Database.EnsureCreated();
+		[Fact]
+		public void TestInDtosNestedOk()
+		{
+			//SETUP
+			var options = SqliteInMemory.CreateOptions<TestDbContext>();
+			using (var context = new TestDbContext(options))
+			{
+				context.Database.EnsureCreated();
 
-                var utData = context.SetupSingleDtoAndEntities<InContactAddressDto>();
-                utData.AddSingleDto<InAddressDto>();
-                var service = new CrudServices(context, utData.ConfigAndMapper);
+				var utData = context.SetupSingleDtoAndEntities<InContactAddressDto>();
+				utData.AddSingleDto<InAddressDto>();
+				var service = new CrudServices(context, utData.ConfigAndMapper);
 
-                //ATTEMPT
-                var dto = new InContactAddressDto
-                {
-                    Name = "test",
-                    Addess = new InAddressDto
-                    {
-                        Address1 = "some street"
-                    }
-                };
-                service.CreateAndSave(dto);
+				//ATTEMPT
+				var dto = new InContactAddressDto
+				{
+					Name = "test",
+					Addess = new InAddressDto
+					{
+						Address1 = "some street"
+					}
+				};
+				service.CreateAndSave(dto);
 
-                //VERIFY
-                service.IsValid.ShouldBeTrue(service.GetAllErrors());
-                var contact = context.ContactAddresses.SingleOrDefault();
-                contact.Name.ShouldEqual("test");
-                contact.Address.Address1.ShouldEqual("some street");
-            }
+				//VERIFY
+				service.IsValid.ShouldBeTrue(service.GetAllErrors());
+				var contact = context.ContactAddresses.SingleOrDefault();
+				contact.Name.ShouldEqual("test");
+				contact.Address.Address1.ShouldEqual("some street");
+			}
 		}
 
 		[Fact]
@@ -77,9 +77,9 @@ namespace Tests.UnitTests.GenericServicesPublic
 				var contact = context.ContactAddresses.SingleOrDefault();
 				contact.Name.ShouldEqual("test");
 
-				IList<InContactAddressDto> resp = service.ReadManyNoTracked<InContactAddressDto>().Where(x => x.Addess.Address1 == "some street").ToList();
+				List<InContactAddressDto> resp = service.ReadManyNoTracked<InContactAddressDto>().Where(x => x.Addess.Address1 == "some street").ToList();
 
-				contact.Address.Address1.ShouldEqual("some street");
+				resp.ForEach(x => x.Addess.Address1.ShouldEqual("some street"));
 			}
 		}
 	}


### PR DESCRIPTION
Hello @JonPSmith ,

we found an Exception when reading nested values from nested dto's.
We also tried to use the PerDtoConfig class to avoid the error but still the error occurs.
To demonstrate that behaviour to you, we just modified the test TestInDtosNestedOk
and added 
TestInDtosNestedOk2
with a linq query that shows the exception

IList<InContactAddressDto> resp = service.ReadManyNoTracked<InContactAddressDto>().Where(x => x.Addess.Address1 == "some street").ToList();

Can you please look at the exception ? Thanks in advance.

System.InvalidOperationException : The LINQ expression 'Where<ContactAddress>(
    source: DbSet<ContactAddress>, 
    predicate: (c) => new InContactAddressDto{ Name = c.Name }
    .Addess.Address1 == "some street")' could not be translated


