### PR TITLE
upgrade to .NET 7 and automapper 12. update other NuGet packages as relevant in .NET 7 target

### DIFF
--- a/Benchmarking/Benchmarking.csproj
+++ b/Benchmarking/Benchmarking.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
     <PackageReference Include="EfCore.TestSupport" Version="5.2.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DataLayer/DataLayer.csproj
+++ b/DataLayer/DataLayer.csproj
@@ -1,19 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net6.0;net7.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.10" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.10" />
-		<PackageReference Include="GenericServices.StatusGeneric" Version="1.1.0" />
+		<PackageReference Include="GenericServices.StatusGeneric" Version="1.2.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" />
-		<PackageReference Include="GenericServices.StatusGeneric" Version="1.1.0" />
+		<PackageReference Include="GenericServices.StatusGeneric" Version="1.2.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
+		<PackageReference Include="GenericServices.StatusGeneric" Version="1.2.0" />
 	</ItemGroup>
 
 </Project>

--- a/GenericServices/GenericServices.csproj
+++ b/GenericServices/GenericServices.csproj
@@ -1,25 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+	  <TargetFrameworks>netstandard2.1;net6.0;net7.0</TargetFrameworks>
 	  <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
-		<PackageReference Include="AutoMapper" Version="10.1.1" />
+		<PackageReference Include="AutoMapper" Version="12.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="5.0.11 " />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.10" />
-		<PackageReference Include="GenericServices.StatusGeneric" Version="1.1.0" />
+		<PackageReference Include="GenericServices.StatusGeneric" Version="1.2.0" />
 	</ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="AutoMapper" Version="12.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
-    <PackageReference Include="GenericServices.StatusGeneric" Version="1.1.0" />
+    <PackageReference Include="GenericServices.StatusGeneric" Version="1.2.0" />
   </ItemGroup>
 
-  <PropertyGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
+		<PackageReference Include="AutoMapper" Version="12.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="7.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+		<PackageReference Include="GenericServices.StatusGeneric" Version="1.2.0" />
+	</ItemGroup>
+
+	<PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageVersion>5.1.1</PackageVersion>
     <Version>5.1.1</Version>

--- a/GenericServices/Internal/Decoders/DecodedEntityClass.cs
+++ b/GenericServices/Internal/Decoders/DecodedEntityClass.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using GenericServices.Configuration.Internal;
 using Microsoft.EntityFrameworkCore;
 using StatusGeneric;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace GenericServices.Internal.Decoders
 {
@@ -53,10 +54,13 @@ namespace GenericServices.Internal.Decoders
                 return;
             }
 
-            // This replaces 'context.Model.FindEntityType(entityType)' because that didn't provide Owned Types
-            var efType = context.Model.GetEntityTypes(entityType)
-                //You can multiple Owned types
-                .FirstOrDefault();
+            //// This replaces 'context.Model.FindEntityType(entityType)' because that didn't provide Owned Types
+            //var efType = context.Model.GetEntityTypes(entityType)
+            //    //You can multiple Owned types
+            //    .FirstOrDefault();
+            var efEntityTypes = context.Model.GetEntityTypes();
+            var efType = efEntityTypes.Where(x => x.ClrType.Name == entityType.Name)
+                                      .FirstOrDefault();
 
             if (efType == null)
             {
@@ -78,7 +82,7 @@ namespace GenericServices.Internal.Decoders
                 return;
             }
 
-            var primaryKeys = efType.GetKeys().Where(x => x.IsPrimaryKey()).ToImmutableList();
+            var primaryKeys = efType.GetKeys().Where(x => (x == x.DeclaringEntityType.FindPrimaryKey())).ToImmutableList();
             if (primaryKeys.Count != 1)
             {
                 throw new InvalidOperationException($"The class {entityType.Name} has {primaryKeys.Count} primary keys. I can't handle that.");

--- a/GenericServices/Setup/Internal/MappingProfile.cs
+++ b/GenericServices/Setup/Internal/MappingProfile.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using AutoMapper;
+using AutoMapper.Internal;
 
 [assembly: InternalsVisibleTo("Tests")]
 
@@ -15,7 +16,7 @@ namespace GenericServices.Setup.Internal
         public MappingProfile(bool addIgnoreParts)
         {
             if (addIgnoreParts)
-                ForAllPropertyMaps(pm => Filter(pm.SourceMember), (pm, opt) => opt.Ignore());
+                this.Internal().ForAllPropertyMaps(pm => Filter(pm.SourceMember), (pm, opt) => opt.Ignore());
         }
 
         /// <summary>

--- a/ServiceLayer/ServiceLayer.csproj
+++ b/ServiceLayer/ServiceLayer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net6.0;net7.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
@@ -13,6 +13,12 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
 		<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
+		<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
 

--- a/Tests/Helpers/UnitTestProfile.cs
+++ b/Tests/Helpers/UnitTestProfile.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Reflection;
 using AutoMapper;
+using AutoMapper.Internal;
 
 namespace Tests.Helpers
 {
@@ -13,7 +14,7 @@ namespace Tests.Helpers
         public UnitTestProfile(bool addIgnoreParts)
         {
             if (addIgnoreParts)
-                ForAllPropertyMaps(pm => Filter(pm.SourceMember), (pm, opt) => opt.Ignore());
+                this.Internal().ForAllPropertyMaps(pm => Filter(pm.SourceMember), (pm, opt) => opt.Ignore());
         }
 
         public void AddReadMap<TIn, TOut>(Action<IMappingExpression<TIn, TOut>> alterMapping = null)

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,47 +1,62 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-	  <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
-
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
-		<PackageReference Include="AutoMapper" Version="10.1.1" />
+		<PackageReference Include="AutoMapper" Version="12.0.0" />
 		<PackageReference Include="EfCore.TestSupport" Version="5.2.2" />
 		<PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="5.0.11" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.10" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
-		<PackageReference Include="GenericServices.StatusGeneric" Version="1.1.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+		<PackageReference Include="GenericServices.StatusGeneric" Version="1.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
 	</ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="EfCore.TestSupport" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.0.0-preview3.21293.2" />
-    <PackageReference Include="GenericServices.StatusGeneric" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="AutoMapper" Version="12.0.0" />
+		<PackageReference Include="EfCore.TestSupport" Version="5.2.2" />
+		<PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="4.0.0-preview3.21293.2" />
+		<PackageReference Include="GenericServices.StatusGeneric" Version="1.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\DataLayer\DataLayer.csproj" />
-    <ProjectReference Include="..\GenericServices\GenericServices.csproj" />
-    <ProjectReference Include="..\ServiceLayer\ServiceLayer.csproj" />
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
+		<PackageReference Include="AutoMapper" Version="12.0.0" />
+		<PackageReference Include="EfCore.TestSupport" Version="5.2.2" />
+		<PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="7.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
+		<PackageReference Include="GenericServices.StatusGeneric" Version="1.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\DataLayer\DataLayer.csproj" />
+		<ProjectReference Include="..\GenericServices\GenericServices.csproj" />
+		<ProjectReference Include="..\ServiceLayer\ServiceLayer.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Tests/UnitTests/Libraries/TestAutoMapper.cs
+++ b/Tests/UnitTests/Libraries/TestAutoMapper.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using AutoMapper;
+using AutoMapper.Internal;
 using AutoMapper.QueryableExtensions;
 using DataLayer.EfClasses;
 using Tests.Configs;
@@ -120,7 +121,7 @@ namespace Tests.UnitTests.Libraries
             var config = new MapperConfiguration(cfg =>
             {
                 //see https://github.com/AutoMapper/AutoMapper/issues/2571#issuecomment-374159340
-                cfg.ForAllPropertyMaps(pm => Filter(pm.SourceMember), (pm, opt) => opt.Ignore());
+                cfg.Internal().ForAllPropertyMaps(pm => Filter(pm.SourceMember), (pm, opt) => opt.Ignore());
                 cfg.CreateMap<WriteAuthorReadOnlyDto, Author>();
             });
 

--- a/Tests/UnitTests/TestIssues/TestIssue60.cs
+++ b/Tests/UnitTests/TestIssues/TestIssue60.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using GenericServices.PublicButHidden;
 using GenericServices.Setup;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using TestSupport.EfHelpers;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
@@ -60,7 +61,8 @@ namespace Tests.UnitTests.TestIssues
             using var context = new Context(options);
 
             //ATTEMPT
-            var ownedTypes = context.Model.GetEntityTypes(typeof(Reference));
+            var ownedTypes = context.Model.GetEntityTypes()
+                                          .Where(x => x.ClrType.Name == typeof(Reference).Name);
 
             //VERIFY
             ownedTypes.Count().ShouldEqual(2);


### PR DESCRIPTION
fixes #65 

I added a target framework for .NET 7 to all projects and verified all included unit tests are passing for all target frameworks. 

I included the update to AutoMapper 12 (similar to another PR) because there appear to be some .NET 7 fixes in that version that prevented a build with AutoMapper 11.0.1 from passing tests.