### PR TITLE
Update SetupAllEntities.cs

### DIFF
--- a/GenericServices/Setup/Internal/SetupAllEntities.cs
+++ b/GenericServices/Setup/Internal/SetupAllEntities.cs
@@ -17,7 +17,7 @@ namespace GenericServices.Setup.Internal
             if (contextTypes == null || contextTypes.Length <= 0)
                 throw new ArgumentException(nameof(contextTypes));
 
-            var serviceProvider = services.BuildServiceProvider();
+            using var serviceProvider = services.BuildServiceProvider();
             var serviceScopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
             using (var serviceScope = serviceScopeFactory.CreateScope())
             {


### PR DESCRIPTION
While debugging my application, I discovered that one of my singleton services were being instantiated twice. I realized that this was due to GenericServicesSimpleSetup building the DI container (SetupAllEntities.cs:20) in order to resolve the DbContext. Since my DbContext depended on a singleton service, it was instantiated twice: once during setup, and again when the application built the root DI container.

My question is this: The temporary IServiceProvider that is built in SetupAllEntities doesn't seem to be used anywhere else. Could it be disposed after resolving the DbContext(s)? Currently you dispose the service scope, but this doesn't trigger Dispose on singleton services.