### PR TITLE
Upgrade to AutoMapper 13.0.1 (all tests pass)

### DIFF
--- a/GenericServices/GenericServices.csproj
+++ b/GenericServices/GenericServices.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AutoMapper" Version="12.0.1" />
+		<PackageReference Include="AutoMapper" Version="13.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
 		<PackageReference Include="GenericServices.StatusGeneric" Version="1.2.0" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AutoMapper" Version="12.0.1" />
+		<PackageReference Include="AutoMapper" Version="13.0.1" />
 		<PackageReference Include="EfCore.TestSupport" Version="8.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.2" />


### PR DESCRIPTION
I expected at least a few code changes would be needed but that doesn't seem to be the case. All tests pass and our application using GenericServices works as expected with these changes in place.

For background, our application uses GenericServices to map between EF entities and DTOs in the app layer. For non-entities, we use AutoMapper to map between DTOs and ViewModels. We also have a reference to the package `AutoMapper.Extensions.Microsoft.DependencyInjection` but v13 rolls this support into the main package. As a result, we have a reference to a package that's now flagged as deprecated, but we can't remove the reference until GenericServices upgrades to v13.

AutoMapper references:
- [13.0 Upgrade Guide](https://docs.automapper.org/en/latest/13.0-Upgrade-Guide.html)
- [Release notes](https://github.com/AutoMapper/AutoMapper/releases/tag/v13.0.0)
- [Changelog](https://github.com/AutoMapper/AutoMapper/compare/v12.0.1...v13.0.0)

