### PR TITLE
Add `ICrudServices.MapEntityToDto()`

### DIFF
--- a/GenericServices/ICrudServices.cs
+++ b/GenericServices/ICrudServices.cs
@@ -60,6 +60,15 @@ namespace GenericServices
             where TEntity : class;
 
         /// <summary>
+        /// This maps an existing entity instance that has already been retrieved to a DTO.
+        /// </summary>
+        /// <typeparam name="TEntity">This must be a entity or query class in the current DbContext</typeparam>
+        /// <typeparam name="TDto">This should be a class with an <see cref="ILinkToEntity{TEntity}"/></typeparam>
+        /// <param name="entity">The entity instance to be mapped to a DTO.</param>
+        /// <returns></returns>
+        TDto MapEntityToDto<TEntity, TDto>(TEntity entity) where TEntity : class;
+
+        /// <summary>
         /// This will create a new entity in the database. If you provide class which is an entity class (i.e. in your EF Core database) then
         /// the method will add, and then call SaveChanges. If the class you provide is a CrudServices DTO which has a <see cref="ILinkToEntity{TEntity}"/> interface
         /// it will use that to create the entity by matching the DTOs properties to either, a) a public static method, b) a public ctor, or 

--- a/GenericServices/ICrudServicesAsync.cs
+++ b/GenericServices/ICrudServicesAsync.cs
@@ -62,6 +62,15 @@ namespace GenericServices
             where TEntity : class;
 
         /// <summary>
+        /// This maps an existing entity instance that has already been retrieved to a DTO.
+        /// </summary>
+        /// <typeparam name="TEntity">This must be a entity or query class in the current DbContext</typeparam>
+        /// <typeparam name="TDto">This should be a class with an <see cref="ILinkToEntity{TEntity}"/></typeparam>
+        /// <param name="entity">The entity instance to be mapped to a DTO.</param>
+        /// <returns></returns>
+        TDto MapEntityToDto<TEntity, TDto>(TEntity entity) where TEntity : class;
+
+        /// <summary>
         /// This will create async a new entity in the database. If you provide class which is an entity class (i.e. in your EF Core database) then
         /// the method will add, and then call SaveChanges. If the class you provide is a CrudServices DTO which has a <see cref="ILinkToEntity{TEntity}"/> interface
         /// it will use that to create the entity by matching the DTOs properties to either, a) a public static method, b) a public ctor, or 

--- a/GenericServices/Internal/MappingCode/CreateMapper.cs
+++ b/GenericServices/Internal/MappingCode/CreateMapper.cs
@@ -71,6 +71,11 @@ namespace GenericServices.Internal.MappingCode
                 _wrappedMapper.MapperSaveConfig.CreateMapper().Map(dto, entity);
             }
 
+            public void MapEntityToDto(TEntity entity, TDto dto)
+            {
+                _wrappedMapper.MapperReadConfig.CreateMapper().Map(entity, dto);
+            }
+
             /// <summary>
             /// This returns the existing entity with any includes applied from the IncludeThenAttribute
             /// </summary>

--- a/GenericServices/PublicButHidden/CrudServices.cs
+++ b/GenericServices/PublicButHidden/CrudServices.cs
@@ -139,6 +139,18 @@ namespace GenericServices.PublicButHidden
         }
 
         /// <inheritdoc />
+        public TDto MapEntityToDto<TEntity, TDto>(TEntity entity) where TEntity : class
+        {
+            var dtoInstance = (TDto)Activator.CreateInstance(typeof(TDto));
+            
+            var entityInfo = _context.GetEntityInfoThrowExceptionIfNotThere(typeof(TEntity));
+            var projector = new CreateMapper(_context, _configAndMapper, typeof(TDto), entityInfo);
+            projector.Accessor.MapEntityToDto(entity, dtoInstance);
+
+            return dtoInstance;
+        }
+
+        /// <inheritdoc />
         public T CreateAndSave<T>(T entityOrDto, string ctorOrStaticMethodName = null) where T : class
         {
             var entityInfo = _context.GetEntityInfoThrowExceptionIfNotThere(typeof(T));

--- a/GenericServices/PublicButHidden/CrudServicesAsync.cs
+++ b/GenericServices/PublicButHidden/CrudServicesAsync.cs
@@ -141,6 +141,18 @@ namespace GenericServices.PublicButHidden
         }
 
         /// <inheritdoc />
+        public TDto MapEntityToDto<TEntity, TDto>(TEntity entity) where TEntity : class
+        {
+            var dtoInstance = (TDto)Activator.CreateInstance(typeof(TDto));
+
+            var entityInfo = _context.GetEntityInfoThrowExceptionIfNotThere(typeof(TEntity));
+            var projector = new CreateMapper(_context, _configAndMapper, typeof(TDto), entityInfo);
+            projector.Accessor.MapEntityToDto(entity, dtoInstance);
+
+            return dtoInstance;
+        }
+
+        /// <inheritdoc />
         public async Task<T> CreateAndSaveAsync<T>(T entityOrDto, string ctorOrStaticMethodName = null) where T : class
         {
             var entityInfo = _context.GetEntityInfoThrowExceptionIfNotThere(typeof(T));


### PR DESCRIPTION
# Add `ICrudServices.MapEntityToDto()`

Exposes a new method that can be used to map an existing entity instance to a DTO using the same mapping config that `ReadSingle()` would use.

## Description

We're using GenericServices in our project to retrieve entities and map them to DTOs, sometimes using `PerDtoConfig` when needed. Using `ReadSingle()` and `ReadManyNoTracked()` work great for most scenarios, but we sometimes run into scenarios where with entities directly. These changes will allow us to continue to use GenericServices to handle mapping an entity to a DTO, even when GenericServices wasn't used to retrieve the data.

One example use case is using static factory methods to get back an instance of an entity with default values assigned. Since this instance isn't persisted anywhere, GenericServices can't be used to retrieve and map it (ex. via `ReadSingle()`). These changes make this possible by calling `MapEntityToDto` and passing in the entity instance to map.

## Notes

No promises on code quality or placement 🤫 but it is functional and all tests pass. I started by looking at `ReadSingle()` and `ProjectFromEntityToDto()` and essentially swapping out the `IQueryable` requirement that retrieves an entity with one that is passed in, so I put the new method in the same area. Somewhere in the process I came across `MapDtoToEntity()` so I thought that was a reasonable place to add a new `MapEntityToDto()`.